### PR TITLE
Build cache

### DIFF
--- a/cget/cli.py
+++ b/cget/cli.py
@@ -87,8 +87,9 @@ def init_command(prefix, toolchain, cc, cxx, cflags, cxxflags, ldflags, std, def
 @click.option('--debug', is_flag=True, help="Install debug version")
 @click.option('--release', is_flag=True, help="Install release version")
 @click.option('--insecure', is_flag=True, help="Don't use https urls")
+@click.option('--use-build-cache', is_flag=True, help="Cache builds")
 @click.argument('pkgs', nargs=-1, type=click.STRING)
-def install_command(prefix, pkgs, define, file, test, test_all, update, generator, cmake, debug, release, insecure):
+def install_command(prefix, pkgs, define, file, test, test_all, update, generator, cmake, debug, release, insecure, use_build_cache):
     """ Install packages """
     if debug and release:
         click.echo("ERROR: debug and release are not supported together")
@@ -102,7 +103,15 @@ def install_command(prefix, pkgs, define, file, test, test_all, update, generato
     for pbu in util.flat([prefix.from_file(file), pbs]):
         pb = pbu.merge_defines(define)
         with prefix.try_("Failed to build package {}".format(pb.to_name()), on_fail=lambda: prefix.remove(pb)):
-            click.echo(prefix.install(pb, test=test, test_all=test_all, update=update, generator=generator, insecure=insecure))
+            click.echo(prefix.install(
+                pb,
+                test=test,
+                test_all=test_all,
+                update=update,
+                generator=generator,
+                insecure=insecure,
+                use_build_cache=use_build_cache
+            ))
 
 @cli.command(name='ignore')
 @use_prefix

--- a/cget/cli.py
+++ b/cget/cli.py
@@ -100,8 +100,6 @@ def install_command(prefix, pkgs, define, file, test, test_all, update, generato
         else: file = 'requirements.txt'
     pbs = [PackageBuild(pkg, cmake=cmake, variant=variant) for pkg in pkgs]
     for pbu in util.flat([prefix.from_file(file), pbs]):
-        hash = prefix.hash_pkg(pbu)
-        print("package '%s' hash %s" % (prefix.parse_pkg_src(pbu).name, hash))
         pb = pbu.merge_defines(define)
         with prefix.try_("Failed to build package {}".format(pb.to_name()), on_fail=lambda: prefix.remove(pb)):
             click.echo(prefix.install(pb, test=test, test_all=test_all, update=update, generator=generator, insecure=insecure))

--- a/cget/cli.py
+++ b/cget/cli.py
@@ -100,6 +100,8 @@ def install_command(prefix, pkgs, define, file, test, test_all, update, generato
         else: file = 'requirements.txt'
     pbs = [PackageBuild(pkg, cmake=cmake, variant=variant) for pkg in pkgs]
     for pbu in util.flat([prefix.from_file(file), pbs]):
+        hash = prefix.hash_pkg(pbu)
+        print("package '%s' hash %s" % (prefix.parse_pkg_src(pbu).name, hash))
         pb = pbu.merge_defines(define)
         with prefix.try_("Failed to build package {}".format(pb.to_name()), on_fail=lambda: prefix.remove(pb)):
             click.echo(prefix.install(pb, test=test, test_all=test_all, update=update, generator=generator, insecure=insecure))

--- a/cget/package.py
+++ b/cget/package.py
@@ -1,4 +1,4 @@
-import base64, copy, argparse, six
+import base64, copy, argparse, six, dirhash, hashlib
 
 def encode_url(url):
     x = six.b(url[url.find('://')+3:])
@@ -31,6 +31,12 @@ class PackageSource:
             return self.url[7:] # Remove "file://"
         raise TypeError()
 
+    def calc_hash(self):
+        if self.recipe:
+            return dirhash.dirhash(self.recipe, "sha1")
+        elif self.url:
+            return hashlib.sha1(self.url.encode("utf-8")).hexdigest()
+        raise Exception("no url or recipe: %s" % self.__dict__)
 
 def fname_to_pkg(fname):
     if fname.startswith('_url_'): return PackageSource(name=decode_url(fname), fname=fname)

--- a/cget/prefix.py
+++ b/cget/prefix.py
@@ -338,6 +338,7 @@ class CGetPrefix:
             if test or test_all: builder.test(variant=pb.variant)
             # Install
             builder.build(target='install', variant=pb.variant)
+            util.zip_dir_to_cache("builds/%s" % pb.to_name(), self.hash_pkg(pb), install_dir)
             if util.USE_SYMLINKS: util.symlink_dir(install_dir, self.prefix)
             else: util.copy_dir(install_dir, self.prefix)
         self.write_parent(pb, track=track)

--- a/cget/prefix.py
+++ b/cget/prefix.py
@@ -1,4 +1,4 @@
-import os, shutil, shlex, six, inspect, click, contextlib, uuid, sys, functools
+import os, shutil, shlex, six, inspect, click, contextlib, uuid, sys, functools, hashlib
 
 from cget.builder import Builder
 from cget.package import fname_to_pkg
@@ -222,6 +222,15 @@ class CGetPrefix:
         else: url = 'https://github.com/{0}/{0}/archive/{1}.tar.gz'.format(p, v)
         if name is None: name = p
         return PackageSource(name=name, url=url)
+
+    def hash_pkg(self, pkg):
+        pkg_src = self.parse_pkg_src(pkg)
+        result = pkg_src.calc_hash()
+        pkg_build = self.parse_pkg_build(pkg)
+        if pkg_build.requirements:
+            for dependency in self.from_file(pkg_build.requirements):
+                result = hashlib.sha1((result + self.hash_pkg(dependency)).encode("utf-8")).hexdigest()
+        return result
 
     @returns(PackageSource)
     @params(pkg=PACKAGE_SOURCE_TYPES)

--- a/cget/util.py
+++ b/cget/util.py
@@ -96,15 +96,26 @@ def zipdir(src_dir, tgt_file):
                 os.path.join(root, file),
                 os.path.relpath(
                     os.path.join(root, file),
-                    os.path.join(src_dir, '..')
+                    os.path.join(src_dir)
                 )
             )
     zipf.close()
 
 def zip_dir_to_cache(prefix, key, src_dir):
-    out_dir = get_cache_path(prefix)
-    mkdir(out_dir)
-    zipdir(src_dir, os.path.join(out_dir, key + ".zip"))
+    cache_dir = get_cache_path(prefix)
+    zipfile_path = os.path.join(cache_dir, key + ".zip")
+    mkdir(cache_dir)
+    zipdir(src_dir, zipfile_path)
+
+def unzip_dir_from_cache(prefix, key, tgt_dir):
+    cache_dir = get_cache_path(prefix)
+    zipfile_path = os.path.join(cache_dir, key + ".zip")
+    if os.path.exists(zipfile_path):
+        f = zipfile.ZipFile(zipfile_path, "r")
+        f.extractall(tgt_dir)
+        return True
+    else:
+        return False
 
 def ls(p, predicate=lambda x:True):
     if os.path.exists(p):

--- a/cget/util.py
+++ b/cget/util.py
@@ -87,6 +87,25 @@ def mkfile(d, file, content, always_write=True):
         write_to(p, content)
     return p
 
+def zipdir(src_dir, tgt_file):
+    print("zipping '%s' to '%s" % (src_dir, tgt_file))
+    zipf = zipfile.ZipFile(tgt_file, 'w', zipfile.ZIP_DEFLATED)
+    for root, dirs, files in os.walk(src_dir):
+        for file in files:
+            zipf.write(
+                os.path.join(root, file),
+                os.path.relpath(
+                    os.path.join(root, file),
+                    os.path.join(src_dir, '..')
+                )
+            )
+    zipf.close()
+
+def zip_dir_to_cache(prefix, key, src_dir):
+    out_dir = get_cache_path(prefix)
+    mkdir(out_dir)
+    zipdir(src_dir, os.path.join(out_dir, key + ".zip"))
+
 def ls(p, predicate=lambda x:True):
     if os.path.exists(p):
         return (d for d in os.listdir(p) if predicate(os.path.join(p, d)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ click>=6.6
 # PyYAML
 six>=1.10
 dirhash>=0.2.1
+filelock>=2.0.13
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ click>=6.6
 six>=1.10
 dirhash>=0.2.1
 filelock>=2.0.13
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click>=6.6
 # PyYAML
 six>=1.10
+dirhash>=0.2.1


### PR DESCRIPTION
- optionally cache builds based on package hash
- the package hash is generated from the recipe and recursively dependencies
- currently only respects dependencies from recipes and not such from the package itself
- also introduces a file lock in the cache to avoid undefined behavior with concurrent cget runs
