### PR TITLE
Fix "cget install --debug"

### DIFF
--- a/cget/cli.py
+++ b/cget/cli.py
@@ -101,6 +101,8 @@ def install_command(prefix, pkgs, define, file, test, test_all, update, generato
     pbs = [PackageBuild(pkg, cmake=cmake, variant=variant) for pkg in pkgs]
     for pbu in util.flat([prefix.from_file(file), pbs]):
         pb = pbu.merge_defines(define)
+        pb.variant = 'Release'
+        if debug: pb.variant = 'Debug'
         with prefix.try_("Failed to build package {}".format(pb.to_name()), on_fail=lambda: prefix.remove(pb)):
             click.echo(prefix.install(pb, test=test, test_all=test_all, update=update, generator=generator, insecure=insecure))
 


### PR DESCRIPTION
When installing packages, the --debug command-line flag was not always
obeyed. It always worked correctly for "cget install --debug
<pkg_name>", and also always worked correctly when installing packages
as part of "cget build --debug". But for "cget install --debug" using
the requirements.txt file, the --debug command-line flag was not
used. This commit fixes it.