### PR TITLE
remove uuid

### DIFF
--- a/cget/package.py
+++ b/cget/package.py
@@ -41,7 +41,7 @@ class PackageSource:
         recipe_h = self.recipe if self.recipe is not None else 'NoneRecipe'
         recipe_h = str2hash(recipe_h)
         total_h = name_h + url_h + fname_h + recipe_h
-        return hashlib.md5(total_h.encode('utf-8')).hexdigest()
+        return hashlib.sha256(total_h.encode('utf-8')).hexdigest()
 
 
 def fname_to_pkg(fname):

--- a/cget/package.py
+++ b/cget/package.py
@@ -31,13 +31,15 @@ class PackageSource:
             return self.url[7:] # Remove "file://"
         raise TypeError()
     def get_hash(self):
-        name_h = hashlib.md5(self.name.encode('utf-8')).hexdigest()
-        url_h = hashlib.md5(self.url.encode('utf-8')).hexdigest()
-        fname_h = hashlib.md5(self.fname.encode('utf-8')).hexdigest()
-        if self.recipe:
-            recipe_h = hashlib.md5(self.recipe.encode('utf-8')).hexdigest()
-        else:
-            recipe_h = hashlib.md5('None'.encode('utf-8')).hexdigest()
+        str2hash = lambda x : hashlib.sha256(x.encode('utf-8')).hexdigest()
+        name_h = self.name if self.name is not None else 'NoneName'
+        name_h = str2hash(name_h)
+        url_h = self.url if self.url is not None else 'NoneURL'
+        url_h = str2hash(url_h)
+        fname_h = self.fname if self.fname is not None else 'NoneFName'
+        fname_h = str2hash(fname_h)
+        recipe_h = self.recipe if self.recipe is not None else 'NoneRecipe'
+        recipe_h = str2hash(recipe_h)
         total_h = name_h + url_h + fname_h + recipe_h
         return hashlib.md5(total_h.encode('utf-8')).hexdigest()
 

--- a/cget/package.py
+++ b/cget/package.py
@@ -1,4 +1,4 @@
-import base64, copy, argparse, six
+import base64, copy, argparse, six, hashlib
 
 def encode_url(url):
     x = six.b(url[url.find('://')+3:])
@@ -30,6 +30,16 @@ class PackageSource:
         if self.url.startswith('file://'):
             return self.url[7:] # Remove "file://"
         raise TypeError()
+    def get_hash(self):
+        name_h = hashlib.md5(self.name.encode('utf-8')).hexdigest()
+        url_h = hashlib.md5(self.url.encode('utf-8')).hexdigest()
+        fname_h = hashlib.md5(self.fname.encode('utf-8')).hexdigest()
+        if self.recipe:
+            recipe_h = hashlib.md5(self.recipe.encode('utf-8')).hexdigest()
+        else:
+            recipe_h = hashlib.md5('None'.encode('utf-8')).hexdigest()
+        total_h = name_h + url_h + fname_h + recipe_h
+        return hashlib.md5(total_h.encode('utf-8')).hexdigest()
 
 
 def fname_to_pkg(fname):

--- a/cget/prefix.py
+++ b/cget/prefix.py
@@ -1,4 +1,4 @@
-import os, shutil, shlex, six, inspect, click, contextlib, uuid, sys, functools
+import os, shutil, shlex, six, inspect, click, contextlib, sys, functools
 
 from cget.builder import Builder
 from cget.package import fname_to_pkg
@@ -183,7 +183,7 @@ class CGetPrefix:
     @contextlib.contextmanager
     def create_builder(self, name, tmp=False):
         pre = ''
-        if tmp: pre = 'tmp-'
+        if tmp: pre = '/tmp/cgettmp-'
         d = self.get_builder_path(pre + name)
         exists = os.path.exists(d)
         util.mkdir(d)
@@ -312,7 +312,7 @@ class CGetPrefix:
             self.write_parent(pb, track=track)
             if update: self.remove(pb)
             else: return "Package {} already installed".format(pb.to_name())
-        with self.create_builder(uuid.uuid4().hex, tmp=True) as builder:
+        with self.create_builder(pb.pkg_src.get_hash(), tmp=True) as builder:
             # Fetch package
             src_dir = builder.fetch(pb.pkg_src.url, pb.hash, (pb.cmake != None), insecure=insecure)
             # Install any dependencies first

--- a/cget/prefix.py
+++ b/cget/prefix.py
@@ -183,8 +183,7 @@ class CGetPrefix:
     @contextlib.contextmanager
     def create_builder(self, name, tmp=False):
         pre = ''
-        if tmp: 
-            pre = os.path.join(tempfile.gettempdir(), 'cget-')
+        if tmp: pre = 'tmp-'
         d = self.get_builder_path(pre + name)
         exists = os.path.exists(d)
         util.mkdir(d)

--- a/cget/prefix.py
+++ b/cget/prefix.py
@@ -1,4 +1,4 @@
-import os, shutil, shlex, six, inspect, click, contextlib, sys, functools
+import os, shutil, shlex, six, inspect, click, contextlib, sys, functools, tempfile
 
 from cget.builder import Builder
 from cget.package import fname_to_pkg
@@ -183,7 +183,7 @@ class CGetPrefix:
     @contextlib.contextmanager
     def create_builder(self, name, tmp=False):
         pre = ''
-        if tmp: pre = '/tmp/cgettmp-'
+        if tmp: pre = os.path.join(tempfile.gettempdir(), 'cget-')
         d = self.get_builder_path(pre + name)
         exists = os.path.exists(d)
         util.mkdir(d)

--- a/cget/prefix.py
+++ b/cget/prefix.py
@@ -183,7 +183,8 @@ class CGetPrefix:
     @contextlib.contextmanager
     def create_builder(self, name, tmp=False):
         pre = ''
-        if tmp: pre = os.path.join(tempfile.gettempdir(), 'cget-')
+        if tmp: 
+            pre = os.path.join(tempfile.gettempdir(), 'cget-')
         d = self.get_builder_path(pre + name)
         exists = os.path.exists(d)
         util.mkdir(d)

--- a/cget/prefix.py
+++ b/cget/prefix.py
@@ -1,4 +1,4 @@
-import os, shutil, shlex, six, inspect, click, contextlib, sys, functools, tempfile
+import os, shutil, shlex, six, inspect, click, contextlib, sys, functools
 
 from cget.builder import Builder
 from cget.package import fname_to_pkg

--- a/cget/util.py
+++ b/cget/util.py
@@ -205,7 +205,7 @@ def copy_to(src, dst_dir):
         if target_exists: os.remove(target)
         shutil.copyfile(src, target)
     else:
-        if target_exists: os.removedirs(target) 
+        if target_exists: shutil.rmtree(target) 
         shutil.copytree(src, target)
     return target
 

--- a/cget/util.py
+++ b/cget/util.py
@@ -200,13 +200,8 @@ def get_dirs(d):
 
 def copy_to(src, dst_dir):
     target = os.path.join(dst_dir, os.path.basename(src))
-    target_exists = os.path.exists(target)
-    if os.path.isfile(src): 
-        if target_exists: os.remove(target)
-        shutil.copyfile(src, target)
-    else:
-        if target_exists: shutil.rmtree(target, ignore_errors=True) 
-        shutil.copytree(src, target)
+    if os.path.isfile(src): shutil.copyfile(src, target)
+    else: shutil.copytree(src, target)
     return target
 
 def symlink_to(src, dst_dir):

--- a/cget/util.py
+++ b/cget/util.py
@@ -200,8 +200,13 @@ def get_dirs(d):
 
 def copy_to(src, dst_dir):
     target = os.path.join(dst_dir, os.path.basename(src))
-    if os.path.isfile(src): shutil.copyfile(src, target)
-    else: shutil.copytree(src, target)
+    target_exists = os.path.exists(target)
+    if os.path.isfile(src): 
+        if target_exists: os.remove(target)
+        shutil.copyfile(src, target)
+    else:
+        if target_exists: os.removedirs(target) 
+        shutil.copytree(src, target)
     return target
 
 def symlink_to(src, dst_dir):

--- a/cget/util.py
+++ b/cget/util.py
@@ -206,7 +206,7 @@ def copy_to(src, dst_dir):
         shutil.copyfile(src, target)
     else:
         if target_exists: shutil.rmtree(target, ignore_errors=True) 
-        shutil.copytree(src, target, dirs_exist_ok=True)
+        shutil.copytree(src, target)
     return target
 
 def symlink_to(src, dst_dir):

--- a/cget/util.py
+++ b/cget/util.py
@@ -205,8 +205,8 @@ def copy_to(src, dst_dir):
         if target_exists: os.remove(target)
         shutil.copyfile(src, target)
     else:
-        if target_exists: shutil.rmtree(target) 
-        shutil.copytree(src, target)
+        if target_exists: shutil.rmtree(target, ignore_errors=True) 
+        shutil.copytree(src, target, dirs_exist_ok=True)
     return target
 
 def symlink_to(src, dst_dir):


### PR DESCRIPTION
cget uses a unique ID for every package download. This results in the file path being different for each build of the same package, resulting in a cache miss in ccache when cget is asked to build a package with `ccache` enabled.

This PR replaces the UUID with a hash of the package source for reproducibility.