### PR TITLE
cmake: allow to run configure scrict from project subdir

### DIFF
--- a/cget/builder.py
+++ b/cget/builder.py
@@ -50,7 +50,7 @@ class Builder:
             util.extract_ar(archive=f, dst=self.top_dir)
         return next(util.get_dirs(self.top_dir))
 
-    def configure(self, src_dir, defines=None, generator=None, install_prefix=None, test=True, variant=None):
+    def configure(self, src_dir, dir=None, defines=None, generator=None, install_prefix=None, test=True, variant=None):
         self.prefix.log("configure")
         util.mkdir(self.build_dir)
         args = [
@@ -65,6 +65,7 @@ class Builder:
         if test: args.extend(['-DBUILD_TESTING=On'])
         else: args.extend(['-DBUILD_TESTING=Off'])
         args.extend(['-DCMAKE_BUILD_TYPE={}'.format(variant or 'Release')])
+        if dir is not None: args.extend([os.path.join(src_dir,dir)])
         if install_prefix is not None: args.extend(['-DCMAKE_INSTALL_PREFIX=' + install_prefix])
         try:
             self.cmake(args=args, cwd=self.build_dir, use_toolchain=True)

--- a/cget/cli.py
+++ b/cget/cli.py
@@ -103,18 +103,19 @@ def init_command(prefix, toolchain, cc, cxx, cflags, cxxflags, ldflags, std, def
 @click.option('-D', '--define', multiple=True, help="Extra configuration variables to pass to CMake")
 @click.option('-G', '--generator', envvar='CGET_GENERATOR', help='Set the generator for CMake to use')
 @click.option('-X', '--cmake', help='Set cmake file to use to build project')
+@click.option('-d', '--dir', help='Use cmake subdir in project for configure step')
 @click.option('--debug', is_flag=True, help="Install debug version")
 @click.option('--release', is_flag=True, help="Install release version")
 @click.option('--build-type', help="Install custom version [Release, Debug, RelWithDebInfo or other cmake build type]")
 @click.option('--insecure', is_flag=True, help="Don't use https urls")
 @click.argument('pkgs', nargs=-1, type=click.STRING)
-def install_command(prefix, pkgs, define, file, test, test_all, update, generator, cmake, debug, release, build_type, insecure):
+def install_command(prefix, pkgs, define, file, test, test_all, update, generator, cmake, dir, debug, release, build_type, insecure):
     """ Install packages """
     variant = get_build_type(debug, release, build_type)
     if not file and not pkgs:
         if os.path.exists('dev-requirements.txt'): file = 'dev-requirements.txt'
         else: file = 'requirements.txt'
-    pbs = [PackageBuild(pkg, cmake=cmake, variant=variant) for pkg in pkgs]
+    pbs = [PackageBuild(pkg, cmake=cmake, dir=dir, variant=variant) for pkg in pkgs]
     for pbu in util.flat([prefix.from_file(file), pbs]):
         pb = pbu.merge_defines(define)
         pb.variant = variant
@@ -135,6 +136,7 @@ def ignore_command(prefix, pkgs):
 @use_prefix
 @click.option('-t', '--test', is_flag=True, help="Test package by running ctest or check target")
 @click.option('-c', '--configure', is_flag=True, help="Configure cmake")
+@click.option('-d', '--dir', help='Use cmake subdir in project for configure step')
 @click.option('-C', '--clean', is_flag=True, help="Remove build directory")
 @click.option('-P', '--path', is_flag=True, help="Show path to build directory")
 @click.option('-D', '--define', multiple=True, help="Extra configuration variables to pass to CMake")
@@ -147,7 +149,7 @@ def ignore_command(prefix, pkgs):
 @click.argument('pkg', nargs=1, default='.', type=click.STRING)
 def build_command(prefix, pkg, define, test, configure, clean, path, yes, target, generator, debug, release, build_type):
     """ Build package """
-    pb = PackageBuild(pkg).merge_defines(define)
+    pb = PackageBuild(pkg, dir=dir).merge_defines(define)
     pb.variant = get_build_type(debug, release, build_type)
     with prefix.try_("Failed to build package {}".format(pb.to_name())):
         if configure: prefix.build_configure(pb)

--- a/cget/package.py
+++ b/cget/package.py
@@ -49,7 +49,7 @@ def fname_to_pkg(fname):
     else: return PackageSource(name=fname.replace('__', '/'), fname=fname)
 
 class PackageBuild:
-    def __init__(self, pkg_src=None, define=None, parent=None, test=False, hash=None, build=None, cmake=None, variant=None, requirements=None, file=None, ignore_requirements=None):
+    def __init__(self, pkg_src=None, define=None, parent=None, test=False, hash=None, build=None, cmake=None, dir=None, variant=None, requirements=None, file=None, ignore_requirements=None):
         self.pkg_src = pkg_src
         self.define = define or []
         self.parent = parent
@@ -57,6 +57,7 @@ class PackageBuild:
         self.build = build
         self.hash = hash
         self.cmake = cmake
+        self.dir = dir
         self.variant = variant or 'Release'
         self.requirements = requirements
         self.ignore_requirements = ignore_requirements
@@ -99,6 +100,7 @@ def parse_pkg_build_tokens(args):
     parser.add_argument('-D', '--define', action='append', default=[])
     parser.add_argument('-H', '--hash')
     parser.add_argument('-X', '--cmake')
+    parser.add_argument('-d', '--dir')
     parser.add_argument('-f', '--file')
     parser.add_argument('-t', '--test', action='store_true')
     parser.add_argument('-b', '--build', action='store_true')

--- a/cget/prefix.py
+++ b/cget/prefix.py
@@ -324,7 +324,7 @@ class CGetPrefix:
                     os.rename(target, os.path.join(src_dir, builder.cmake_original_file))
                 shutil.copyfile(pb.cmake, target)
             # Configure and build
-            builder.configure(src_dir, defines=pb.define, generator=generator, install_prefix=install_dir, test=test, variant=pb.variant)
+            builder.configure(src_dir, dir=pb.dir, defines=pb.define, generator=generator, install_prefix=install_dir, test=test, variant=pb.variant)
             builder.build(variant=pb.variant)
             # Run tests if enabled
             if test or test_all: builder.test(variant=pb.variant)
@@ -359,7 +359,7 @@ class CGetPrefix:
             # Install any dependencies first
             self.install_deps(pb, src_dir, generator=generator, test=test)
             # Configure and build
-            if not builder.exists: builder.configure(src_dir, defines=pb.define, generator=generator, test=test, variant=pb.variant)
+            if not builder.exists: builder.configure(src_dir, dir=pb.dir, defines=pb.define, generator=generator, test=test, variant=pb.variant)
             builder.build(variant=pb.variant, target=target)
             # Run tests if enabled
             if test: builder.test(variant=pb.variant)

--- a/test/test_cget.py
+++ b/test/test_cget.py
@@ -1009,3 +1009,6 @@ def test_cmake_trouble(d):
 
 def test_subdir(d):
     d.cmds(install_cmds(url='-X subdir {}'.format(get_exists_path('libsimplesubdir')), lib='simple', alias=get_exists_path('libsimplesubdir')))
+
+def test_subdir_exist(d):
+    d.cmds(install_cmds(url='-d cmake {}'.format(get_exists_path('libsimplesubdir')), lib='simple', alias=get_exists_path('libsimplesubdir')))


### PR DESCRIPTION
Option for use subdir to configure cmake project (see [lz4](https://github.com/lz4/lz4/tree/dev/build/cmake) for example).