### PR TITLE
Fix disappearing environment variables

### DIFF
--- a/cget/util.py
+++ b/cget/util.py
@@ -295,7 +295,13 @@ def which(p, paths=None, throws=True):
 def merge(*args):
     result = {}
     for d in args:
-        result.update(dict(d or {}))
+        if d is None:
+            continue
+        for key, val in dict(d or {}).items():
+            if key in result:
+                result[key] = result[key] + ":" + val
+            else:
+                result[key] = val
     return result
 
 def flat(*args):


### PR DESCRIPTION
This PR fixes the problem of environment variable as LD_LIBRARY_PATH being unset by cget. This fixes #110  